### PR TITLE
WIP: add --lazy-apps to uwsgi command line

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,7 +9,7 @@ if [ -f ./work/token ] ; then
 fi
 
 if [ $# -eq 0 ] ; then
-  sh ./scripts/start_server.sh
+  sh ./scripts/start_lazy_uwsgi_server.sh
 elif [ "${1}" = "test" ] ; then
   echo "Run Tests"
   make test

--- a/scripts/start_lazy_uwsgi_server.sh
+++ b/scripts/start_lazy_uwsgi_server.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+script_dir=$(dirname "$(readlink -f "$0")")
+export KB_DEPLOYMENT_CONFIG=$script_dir/../deploy.cfg
+export PYTHONPATH=$script_dir/../lib:$PATH:$PYTHONPATH
+uwsgi --master --lazy-apps --processes 5 --threads 5 --http :5000 --wsgi-file $script_dir/../lib/kb_Metrics/kb_MetricsServer.py


### PR DESCRIPTION
On initial startup there is an error about "No servers found yet" looking for a mongodb server.  According to https://stackoverflow.com/questions/31030307/why-is-pymongo-3-giving-serverselectiontimeouterror/31194981#31194981 , adding --lazy-apps might help prevent that problem.

This patch is completely untested.