### PR TITLE
more perf work for get_app_metrics

### DIFF
--- a/kb_Metrics.spec
+++ b/kb_Metrics.spec
@@ -37,10 +37,13 @@ module kb_Metrics {
     typedef structure {
         list<user_id> user_ids;
         epoch_range epoch_range;
+        int offset;
+        int limit;
     } AppMetricsParams;
 
     typedef structure {
         UnspecifiedObject job_states;
+        int total_count;
     } AppMetricsResult;
 
     typedef structure {

--- a/lib/kb_Metrics/Util.py
+++ b/lib/kb_Metrics/Util.py
@@ -19,6 +19,11 @@ def _unix_time_millis_from_datetime(dt):
 
     return int((dt.replace(tzinfo=None) - epoch).total_seconds() * 1000)
 
+epoch = datetime.datetime.utcfromtimestamp(0)
+
+def _unix_time_millis_from_datetime_trusted(dt):
+    return int((dt.replace(tzinfo=None) - epoch).total_seconds() * 1000)
+
 
 def _convert_to_datetime(dt):
     if type(dt) in [datetime.date, datetime.datetime]:

--- a/lib/kb_Metrics/kb_MetricsImpl.py
+++ b/lib/kb_Metrics/kb_MetricsImpl.py
@@ -5,6 +5,7 @@ from kb_Metrics.metricsdb_controller import MetricsMongoDBController
 import time
 #END_HEADER
 
+
 class kb_Metrics:
     '''
     Module Name:
@@ -23,7 +24,7 @@ This KBase SDK module implements methods for generating various KBase metrics.
     ######################################### noqa
     VERSION = "1.3.0"
     GIT_URL = "https://github.com/kbaseapps/kb_Metrics"
-    GIT_COMMIT_HASH = "f4b51ba9746254fb9e7cfa2fa93d8c63fabb1814"
+    GIT_COMMIT_HASH = "1e031bd6c9b4410df8765231ccfa3a4359266b31"
 
     #BEGIN_CLASS_HEADER
     # Class variables and functions can be defined in this block
@@ -50,9 +51,10 @@ This KBase SDK module implements methods for generating various KBase metrics.
            of size 2: parameter "e_lowerbound" of type "epoch" (A Unix epoch
            (the time since 00:00:00 1/1/1970 UTC) in milliseconds.),
            parameter "e_upperbound" of type "epoch" (A Unix epoch (the time
-           since 00:00:00 1/1/1970 UTC) in milliseconds.)
+           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "offset"
+           of Long, parameter "limit" of Long
         :returns: instance of type "AppMetricsResult" -> structure: parameter
-           "job_states" of unspecified object
+           "job_states" of unspecified object, parameter "total_count" of Long
         """
         # ctx is the context object
         # return variables are: return_records


### PR DESCRIPTION
- add paging
- simpler time conversion for one loop use case (python is sloooow)
- add search by job id strategy for exec query